### PR TITLE
Allow hyphens in regex validating the mysql host

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -17,7 +17,7 @@ class MysqlConnectionData:
     _compiled_regex = re.compile(
         r"^mysql\:\/\/{}@{}\/{}?$".format(
             r"(?P<username>[_\w]+):(?P<password>[\w\W]+)",
-            r"(?P<host>[\.\w]+):(?P<port>\d+)",
+            r"(?P<host>[\-\.\w]+):(?P<port>\d+)",
             r"(?P<database>[_\w]+)",
         )
     )


### PR DESCRIPTION
# Issue
We would like to integrate the new [mysql k8s charm](https://github.com/canonical/mysql-k8s-operator) with this charm. However, the mysql k8s charm utilizes endpoints as mysql hosts (which contain hyphens). There is a regex validating the mysql host that does not accept hyphens.

# Solution
Accept hyphens when validating the mysql host

# Release Notes
- Allow hyphens in regex validating the mysql host